### PR TITLE
Parse plain i as 0.0+1.0i and -i as 0.0-1.0i

### DIFF
--- a/com/abdulfatir/jcomplexnumber/ComplexNumber.java
+++ b/com/abdulfatir/jcomplexnumber/ComplexNumber.java
@@ -347,6 +347,8 @@ public class ComplexNumber
 			{
 				s = s.replaceAll("i","");
 				s = s.replaceAll("I","");
+                if (s.equals("")) { s = "1"; }
+                else if (s.equals("-")) { s = "-1"; }
 				parsed = new ComplexNumber(0, Double.parseDouble(s));
 			}
 			// Pure real number


### PR DESCRIPTION
Sometimes, a complex number 0 + 1i is simply written as i. The same goes for 0 - 1I written as -i. This pull request fixes the parser to handle these notations.